### PR TITLE
Links logrus and glog to their official github page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # glog4logrus
 
-Print logrus logs with glog.
+Print [logrus](https://github.com/sirupsen/logrus) logs with [glog](https://github.com/golang/glog).
 
 ## Purpose
 


### PR DESCRIPTION
To get better understanding of glog4logrus and why it is developed, linked logrus and glog github repositories to glog4logrus README.